### PR TITLE
#5 Junyoung 3/3

### DIFF
--- a/#5 230118/Q1_Boj_1890_점프/Solution.kt
+++ b/#5 230118/Q1_Boj_1890_점프/Solution.kt
@@ -1,0 +1,47 @@
+
+var n = 0
+lateinit var board: Array<IntArray>
+lateinit var dp: Array<LongArray>
+
+// 오른쪽, 아래 방향으로만 이동한다.
+val dir = arrayOf(
+    arrayOf(1, 0),
+    arrayOf(0, 1)
+)
+
+fun input() = with(System.`in`.bufferedReader()) {
+    n = readLine().toInt()
+    board = Array(n) { readLine().split(" ").map { it.toInt() }.toIntArray() }
+    dp = Array(n) { LongArray(n) { -1L } }
+
+    // dp[x][y] -> x, y 지점에서 목적지 까지 가는 경로의 수
+    // 목적지에서 목적지로 가는 경로는 한 가지
+    dp[n - 1][n - 1] = 1
+}
+
+fun solve() {
+    println(dfs(0, 0))
+}
+
+fun dfs(row: Int, col: Int): Long {
+    // 이미 해당 지점을 방문한 적이 있으면 dp 리턴
+    if (dp[row][col] != -1L) return dp[row][col]
+
+    dp[row][col] = 0
+    dir.forEach {
+        val nr = row + it[0] * board[row][col]
+        val nc = col + it[1] * board[row][col]
+
+        if (nr !in 0 until n || nc !in 0 until n) return@forEach
+
+        // 백트랙킹으로 현 지점에서 목적지 까지의 경우를 누적 시킨다.
+        dp[row][col] += dfs(nr, nc)
+    }
+
+    return dp[row][col]
+}
+
+fun main() {
+    input()
+    solve()
+}

--- a/#5 230118/Q2_Boj_12851_숨바꼭질 2/Solution.kt
+++ b/#5 230118/Q2_Boj_12851_숨바꼭질 2/Solution.kt
@@ -1,0 +1,75 @@
+import java.util.LinkedList
+
+const val MAX = 100_000
+var n = 0
+var k = 0
+lateinit var time: IntArray
+
+fun input() = with(System.`in`.bufferedReader()) {
+    readLine().split(" ").map { it.toInt() }.let {
+        n = it[0]
+        k = it[1]
+    }
+    time = IntArray(MAX + 1)
+}
+
+fun solve() {
+    // 왼쪽으로 가는 경우는 오직 한 가지 밖에 없으므로
+    // 처음에 n이 k 이상이면 bfs를 돌릴 가치가 없다.
+    if (n >= k) {
+        print(buildString {
+            appendLine(n - k)
+            appendLine(1)
+        })
+        return
+    }
+
+    val count = bfs()
+    print(buildString {
+        appendLine(time[k])
+        appendLine(count)
+    })
+}
+
+fun bfs(): Int {
+    var count = 0 // 최단 경로로 k 까지 가는 경우의 수
+    var min = Int.MAX_VALUE // k 까지 가는 최단 경로
+    val que = LinkedList<Int>().apply {
+        add(n)
+        time[n] = 0
+    }
+
+    while (que.isNotEmpty()) {
+        val loc = que.poll()
+
+        // 현재 지점 까지 온 시간이 목적지 까지 가는 시간 이상이면 더 이상 탐색할 가치가 없다.
+        if (time[loc] >= min) continue
+
+        listOf(loc - 1, loc + 1, loc * 2).forEach { next ->
+            when {
+                // case 1 : 다음 지점이 범위를 벗어나면 continue
+                next !in 0 .. MAX || next == n -> {}
+
+                // case 2 : 다음 지점이 목적지 이면 que 삽입 대신 count와 min 갱신
+                next == k -> {
+                    time[k] = time[loc] + 1
+                    min = time[k]
+                    count++
+                }
+
+                // case 3 : 다음 지점에 방문한 적이 없거나 한 번더 방문할 가치가 있으면 탐색
+                time[next] == 0 || time[next] == time[loc] + 1 -> {
+                    que.add(next)
+                    time[next] = time[loc] + 1
+                }
+            }
+        }
+    }
+
+    return count
+}
+
+fun main() {
+    input()
+    solve()
+}

--- a/#5 230118/Q3_Boj_1766_문제집/Solution.kt
+++ b/#5 230118/Q3_Boj_1766_문제집/Solution.kt
@@ -1,0 +1,57 @@
+import java.util.PriorityQueue
+
+var n = 0
+var m = 0
+lateinit var graph: Array<HashSet<Int>>
+lateinit var indegree: IntArray
+lateinit var visit: BooleanArray
+
+fun input() = with(System.`in`.bufferedReader()) {
+    readLine().split(" ").map { it.toInt() }.let {
+        n = it[0]
+        m = it[1]
+    }
+    graph = Array(n + 1) { hashSetOf() }
+    indegree = IntArray(n + 1)
+    visit = BooleanArray(n + 1)
+
+    repeat(m) {
+        val (from, to) = readLine().split(" ").map { it.toInt() }
+
+        graph[from].add(to)
+        indegree[to]++
+    }
+}
+
+fun solve() {
+    val sb = StringBuilder()
+    val que = PriorityQueue<Int>() // 난이도가 쉬운 문제에 우선권을 부여한다.
+    (1 .. n).forEach {
+        // 차수가 0인 문제 (먼저 풀면 좋은 문제)를 큐에 미리 삽입한다.
+        if (indegree[it] == 0) {
+            que.add(it)
+            visit[it] = true
+        }
+    }
+
+    while (que.isNotEmpty()) {
+        val from = que.poll()
+        sb.append(from).append(' ')
+
+        // 현재 문제에 방향성을 갖는 문제들의 차수를 감소시키고
+        // 차수가 0이 되면 큐에 삽입한다.
+        graph[from].forEach { to ->
+            if (!visit[to] && --indegree[to] == 0) {
+                que.add(to)
+                visit[to] = true
+            }
+        }
+    }
+
+    println(sb)
+}
+
+fun main() {
+    input()
+    solve()
+}


### PR DESCRIPTION
### Q1. 백준_점프 (Success)
1. **난이도** : Silver 1
2. **풀이 핵심** : dp, 백트랙킹
3. **복잡도** : O(n^2)

4. **전체적인 알고리즘**
         - 다음과 같이 dp 배열을 정의한다.
         - dp[x][y] -> x, y 지점에서 목적지 까지 가는 경로의 수
         - 0, 0 에서 출발하여 백트랙킹으로 경로의 수를 누적 시킨다.

---

### Q2. 백준_숨바꼭질 2 (Success)
1. **난이도** : Gold 4
2. **풀이 핵심** : bfs
3. **복잡도** : O(100,000)

4. **전체적인 알고리즘**
         - 왼쪽으로 이동하는 경우가 한 가지 밖에 없으므로 n >= k 이면 bfs를 돌릴 가치가 없다.
         - n < k 이면 bfs로 탐색한다.
         - 특정 지점에서 다음 지점으로 이동할 때 다음의 경우에 따라 알맞게 처리한다.
         - 첫째, 다음 지점이 범위를 벗어나는 경우 -> 이동 x
         - 둘째, 다음 지점이 목적지인 경우 -> update ans
         - 셋째, 다음 지점이 목적지는 아니지만 탐색할 가치가 있는 경우 -> 이어서 탐색

--- 이하 2번 문제 회고 ---

5. **범위를 벗어나면 왜 안되는가**
         - 문제의 조건에는 두 사람의 시작 지점 범위만 주어진다.
         - 따라서 찾는 사람이 이동을 하는 도중 100,000을 넘어갈 수 있다고 생각했다.
         - 예를 들어 100,002 에서 왼쪽으로 두 칸 이동한 경우가 최소인 경우가 있을 것이라 생각했다.
         - 그러나 특정 지점 x > 50000 일 때, 100,000 지점으로 이동하고자 한다면
         - 무조건 50000 까지 좌로 이동 후 순간 이동 하는 것이 유리하다. (몇몇의 예시를 대입해보면 자명하다)

6. **visit 처리의 모호함**
         - 출발지 1 에서 목적지 4로 가는 경우를 살펴보면 다음의 두 가지 경우가 있다.
         - 오른쪽으로 한 칸 이동(2) -> 순간이동(4)
         - 순간이동(2) -> 순간이동(4)
         - bfs를 돌리며 visit 처리로 인해 2 지점을 중복하여 방문하지 못하는 경우를 처리해야 한다.

7. **1번 문제 처럼 dp와 dfs로는 풀 수 없는가**
         - 원래 처음 시도했던 방법이 1번 문제의 풀이와 동일했다.
         - 두 문제 모두 최단 경로 수를 구하는 문제이기 때문이다.
         - 하지만 1번 문제는 이동하는 방향이 오른쪽과 아래로 제한되어 있다. 
         - 즉, 목적지에 도달하기만 하면 그것이 최단 경로임이 보장된다.
         - 반면 본 문제는 목적지에 도달하더라도 그것이 최단 경로인지 보장할 수 없으므로 상당히 까다로웠다.

---

### Q3. 문제 (Success)
1. **난이도** : Gold 2
2. **풀이 핵심** : 위상 정렬
3. **복잡도** : O(nlogn) 

4. **전체적인 알고리즘**
         - 위상 정렬을 사용하면 쉽게 구할 수 있다.
         - 다만 차수가 0인 문제를 삽입했을 때 난이도가 쉬운 문제가 우선권을 가져야 하므로
         - 일반 적인 큐 대신 우선 순위 큐를 사용했다.