### PR TITLE
#8 Retry Junyoung

### DIFF
--- a/#8 230201/Q2_Pro_인사고과/Solution.kt
+++ b/#8 230201/Q2_Pro_인사고과/Solution.kt
@@ -1,3 +1,33 @@
+class Solution {
+    fun solution(scores: Array<IntArray>): Int {
+        val target = scores[0] // 첫번째 정보가 완호의 점수
+        var maxEvaluation = 0  // 루프를 돌며 최대 동료 평가 점수를 갱신
+        var rank = 1
+
+        /**
+         * 주어진 scores를 다음과 같이 정렬 후 순회한다.
+         * 1. 근무 태도 점수의 내림차 순
+         * 2. 동료 평가 점수의 오름차 순
+         */
+        scores.sortedWith(compareBy({ -it[0] }, { it[1] })).forEach { score ->
+            if (score[1] >= maxEvaluation) {
+                maxEvaluation = score[1]
+            }
+            // 최대 동료 평가 점수가 갱신 되지 않는 다면 해당 사람은 인센티브 자격이 없다.
+            else {
+                if (score.contentEquals(target)) return -1 // 그 사람이 완호라면 -1
+                return@forEach // continue
+            }
+
+            // 현재 사람이 완호 보다 총합 점수가 높으면 완호의 순위는 하락한다.
+            if (score.sum() > target.sum()) rank++
+        }
+
+        return rank
+    }
+}
+
+/**
 data class Person(
     val id: Int,
     val attitude: Int = 0,
@@ -26,3 +56,4 @@ class Solution {
             .let { if (it < 0) -1 else it + 1 }
     }
 }
+ */

--- a/#8 230201/Q3_Pro_등대/Solution.kt
+++ b/#8 230201/Q3_Pro_등대/Solution.kt
@@ -1,3 +1,47 @@
+class Solution {
+    /**
+     * dp[x] -> x 등대를 루트로 둔다.
+     * dp[x][0] : x 등대를 껐을 때 켜진 등대의 수
+     * dp[x][1] : x 등대를 켰을 때 켜진 등대의 수
+     */
+    lateinit var graph: Array<HashSet<Int>>
+    lateinit var dp: Array<IntArray>
+    lateinit var visit: BooleanArray
+
+    fun solution(n: Int, lighthouse: Array<IntArray>): Int {
+        graph = Array(n + 1) { hashSetOf() }
+        dp = Array(n + 1) { intArrayOf(0, 1) }
+        visit = BooleanArray(n + 1)
+
+        // 그래프 형성
+        lighthouse.forEach { info ->
+            val (from, to) = info
+
+            graph[from].add(to)
+            graph[to].add(from)
+        }
+
+        // 1번 등대를 루트로 두고 차례로 탐색한다.
+        dfs(1)
+
+        return dp[1].minOf { it }
+    }
+
+    fun dfs(from: Int) {
+        visit[from] = true
+
+        graph[from].forEach { to ->
+            if (visit[to]) return@forEach
+
+            dfs(to)
+
+            dp[from][0] += dp[to][1] // from 등대를 안켰으면 to 등대는 무조건 켠다.
+            dp[from][1] += dp[to].minOf { it } // from 등대를 켰으면 to 등대는 켜거나 끄거나
+        }
+    }
+}
+
+/**
 import java.util.LinkedList
 
 class Solution {
@@ -77,3 +121,4 @@ fun main() {
         Solution().solution(n, lighthouse)
     )
 }
+ */


### PR DESCRIPTION
### 8회차_2번_프로그래머스_인사고과 (Finally)

1. **오답 원인**
       - 주어진 조건을 제대로 확인하지 않고 시도했다.
       - 모든 직원의 순위를 매겨야 한다는 생각에서 벗어나지 못했다.
       - 따라서 n^2의 복잡도를 해결할 수 없었다.

2. **풀이 핵심** : 정렬
3. **복잡도** : O(nlogn)
4. **전체적인 알고리즘**
       - scores 배열을 다음과 같이 정렬한다.
       - 1) 근무 태도의 내림차 순
       - 2) 동료 평가의 오름차 순
       - 정렬된 배열을 순회하며 **동료 평가 점수의 최댓값을 갱신**해 간다.
       - 만약 **동료 평가 점수 최댓값이 갱신되지 않는다면** 
       - 해당 사람은 근무 태도 점수 역시 낮다는 것이 보장된다. **즉 인센티브 자격이 없다.**
       - 인센티브 자격이 있는 사람이라면 완호와 총합 점수를 비교하여 석차를 갱신한다. 


### 8회차_3번_프로그래머스_등대 (Finally)

1. **오답 원인**
       - **위상 정렬**로 시도하였고 특정 반례를 찾을 수 없었다.
       - 다른 알고리즘을 생각할 시간이 부족했다.
       
2. **풀이 핵심** : dfs + dp
3. **복잡도** : O(n)
4. **전체적인 알고리즘**
         - 다음과 같이 dp를 정의한다.
         - dp[x][0] : **x 등대를 껐을 때** 켜진 등대의 수
         - dp[x][1] : **x 등대를 켰을 때** 꺼진 등대의 수
         - 1번 등대를 루트로 두고 dfs 탐색을 한다.
         - 현재 노드(from)를 끈다면 다음 노드는 무조건 켜야한다 => **dp[from][0] += dp[to][1]**
         - 현재 노드를 켠다면 다음 노드는 꺼도 되고 켜도 된다 => **dp[from][1] += min(dp[to][0], dp[to][1])**
