### PR TITLE
#7, 8 Retry YoonJae 2/2

### DIFF
--- a/#7 230130/Boj_16113 시그널/Main.java
+++ b/#7 230130/Boj_16113 시그널/Main.java
@@ -26,7 +26,10 @@ public class Main {
                     else
                         sb.append(startByOne());
                 }
-                else sb.append(1);
+                else {
+                    sb.append(1);
+                    index++;
+                }
             }
             else index++;
         }

--- a/#8 230201/pro_등대/Solution.java
+++ b/#8 230201/pro_등대/Solution.java
@@ -1,0 +1,64 @@
+import java.io.IOException;
+import java.util.*;
+
+public class Solution {
+    static List<List<Integer>> graph;
+    static int[] indgree;
+ //   static boolean[] isSafe;
+    static int solution(int n, int[][] lighthouse) {
+        int answer = 0;
+        init(n, lighthouse);
+        answer = bfs();
+        return answer;
+    }
+    static void init(int n, int[][] lighthouse){
+        int a, b;
+        graph = new ArrayList<>();
+        indgree = new int[n + 1];
+    //    isSafe = new boolean[n + 1];
+        for(int i = 0; i < n + 1; i++){
+            graph.add(new ArrayList<>());
+        }
+        for(int i = 0; i < lighthouse.length; i++){
+            a = lighthouse[i][0];
+            b = lighthouse[i][1];
+            graph.get(a).add(b);
+            graph.get(b).add(a);
+            indgree[a]++;
+            indgree[b]++;
+        }
+        System.out.println(graph.size());
+    }
+    static int bfs(){
+        int cnt = 0;
+        Queue<Integer> q = new LinkedList<>();
+        for(int i = 1; i < graph.size(); i++){
+            if(indgree[i] == 1){
+                q.offer(i);
+            }
+        }
+        while(!q.isEmpty()){
+            int pre = q.poll();
+        //    if(isSafe[pre]) continue;
+            if(graph.get(pre).size() == 0) continue;
+            int cur = graph.get(pre).get(0); // 차수가 1인 노드만 넣었으므로 탐색할 가치가 있는 유일한 노드
+            if(graph.get(cur).size() == 0) continue;
+        //    isSafe[cur] = true;
+            cnt++;
+            for(int i = 0; i < graph.get(cur).size(); i++){
+                int next = graph.get(cur).get(i);
+         //       isSafe[next] = true;
+                graph.get(next).remove(Integer.valueOf(cur));
+                indgree[next]--;
+                if(indgree[next] == 1) q.offer(next);
+            }
+            graph.get(cur).clear();
+        }
+        return cnt;
+    }
+    public static void main(String[] args) throws IOException {
+        int n = 10;
+        int[][] lighthouse = {{1, 2}, {1, 3}, {1, 4}, {1, 5}, {5, 6}, {5, 7}, {5, 8}};
+        System.out.println(solution(n, lighthouse));
+    }
+}


### PR DESCRIPTION
### Q1. 백준 16113 시그널 (Finally)
1. **난이도** : Silver 2
2. **풀이 핵심** : 구현, 문자열 분리
3. **복잡도** : O(n)
4. **전체적인 알고리즘** : 
- 입력받은 문자열을 다섯 개로 나눠 2차원 문자 배열에 넣는다
- 맨 윗 줄 첫번째 문자부터 탐색하며 '#'이 나왔을 때 그 다음 문자가 '#'이 아니라면 1, 4 중 무언인지 판단하는 함수를 호출하고 '#'이면 그 외 숫자들을 판단하는 함수를 호출한다.
- 1과 4는 마지막 줄 맨 왼쪽이 '#'이면 1, '#'이 아니면 4
- 나머지는 이렇게.. ㅎㅎ
![image](https://user-images.githubusercontent.com/76997543/216650308-173278b6-9bc4-4023-8515-ef3399412cb9.png)

5. **메모리 초과가 났던 이유** : 
- substring과 toCharArray의 동작을 찾아보면 메모리 초과의 이유를 알 것 같다는 리뷰를 받아 여기서 무엇이 문제였는지 찾아보았다.
- substring은 String 객체를 문자열로 변환하고 주어진 두 개의 인수를 사용해 인덱스의 시작부터 끝(끝은 포함하지 않음)까지 하위 문자열을 반환하는 동작을 한다.
- toCharArray는 String으로 받은 문자열을 char 문자로 다 쪼갠 뒤 char[]배열에 순서대로 값을 넣어 반환한다.
- 이에 substring통해 반환된 것이 String객체가 아닌 String 값이기 때문에 toCharArray가 제대로 동작하지 않는 것인가 싶었지만 명확한 해답을 찾을 수 없었다.(알면 알려주시길...)
- 다른 사람의 코드를 찾아보던 중 나와 똑같이 substring과 toCharArray를 동시에 사용한 코드를 발견 -> 이게 문제가 아닐 수 있겠다.
- 다시 내 코드를 뜯어보던 중 맨 윗줄에서 index가 이동하지 않는 경우가 있다는 것을 찾아냈다.
- index가 늘어나지 않고 무한루프 안에서 StringBuilder에 주구장창 1을 넣고 있었던 것
- while문을 사용할 때 무한 루프에 빠지지 않도록 조건들을 꼼꼼히 살펴야겠다
-----------------------------------
### Q2. 프로그래머스 등대 (Finally)
1. **난이도** : Level 3
2. **풀이 핵심** : bfs, 그래프 구현
3. **복잡도** : O((V+E) * n?)
- 풀고나서 생각났는데 간선을 끊어주는 과정에서 List에서 remove를 해주는데 이 메소드의 시간복잡도가 O(n)임. 등대를 켜줄 때만 사용되기 때문에 시간초과가 나지 않은 것인지..
4. **전체적인 알고리즘** : 
- 최소한의 등대를 켜서 모든 경로가 안전하게 하려면 차수가 1인 노드와 연결된 노드를 켜는 것이 유리함.
- 차수가 1인 노드들을 큐에 넣어주고 하나씩 빼주면서 그 노드(pre)와 연결된 유일한 노드(cur). 그 노드와 연결된 노드들(next)과의 연결을 끊어줌(간선이 안전하기 때문에)
- 노드들(next)의 차수가 1이라면 탐색할 가치가 있으므로 큐에 삽입.
- 위 과정을 반복하며 간선을 끊어준 횟수를 카운트
5. **어려웠던 점** : 
- 인접한 노드들 중 적어도 하나의 켜진 노드가 있을 때 그 노드는 안전하다라는 생각으로 접근함
![제목 없음](https://user-images.githubusercontent.com/76997543/216651172-c5947b77-bcf3-4d7b-b861-f1aefbe5f793.png)

- 절반 이상의 테스트 케이스가 통과되지 않아. 프로그래머스 질문 목록에서 반례를 찾던 중 나와 같은 방식으로 푼 사람을 발견함
- 그 노드 근처에 켜진 노드가 있는 것이 중요한 게 아닌 간선이 안전해야 하는 문제라는 것을 파악함
- 문제를 읽고 완전히 이해하는 노력이 필요할 것 같음
