### PR TITLE
#10 Junyoung 2/3

### DIFF
--- a/#10 230208/Q1_Pro_뒤에 있는 큰 수 찾기/Solution.kt
+++ b/#10 230208/Q1_Pro_뒤에 있는 큰 수 찾기/Solution.kt
@@ -1,0 +1,43 @@
+import java.util.LinkedList
+
+class Solution {
+    fun solution(numbers: IntArray): IntArray {
+        val stack = LinkedList<Int>()
+        val n = numbers.size
+        var i = 0 // numbers에 접근할 인덱스
+
+        val ans = IntArray(n)
+        while (i < n) {
+            val num = numbers[i]
+
+            when {
+                // case 1: 스택이 비어있음 -> 단순 삽입
+                stack.isEmpty() -> stack.push(i++ to num)
+
+                // case 2: 스택의 top이 현재 수 보다 작음 -> top의 뒷 큰수 저장
+                stack.top() < num -> {
+                    val (_, index) = stack.pop() to stack.pop()
+                    ans[index] = num
+                }
+
+                // case 3: 스택의 top이 현재 수와 같거나 큼 -> 현재 수 삽입
+                stack.top() >= num -> stack.push(i++ to num)
+            }
+        }
+
+        // 뒷 큰수가 없는 수에 -1 저장
+        while (stack.isNotEmpty()) {
+            val (_, index) = stack.pop() to stack.pop()
+            ans[index] = -1
+        }
+
+        return ans
+    }
+}
+
+fun LinkedList<Int>.top(): Int = peekFirst()
+
+fun LinkedList<Int>.push(info: Pair<Int, Int>) = apply {
+    push(info.first)
+    push(info.second)
+}

--- a/#10 230208/Q2_Pro_시소 짝꿍/Solution.kt
+++ b/#10 230208/Q2_Pro_시소 짝꿍/Solution.kt
@@ -1,0 +1,22 @@
+class Solution {
+    // weight, count 쌍으로 저장할 HashMap
+    val map = hashMapOf<Int, Long>()
+    val rates = listOf(1 to 2, 2 to 3, 3 to 4)
+
+    fun solution(weights: IntArray): Long {
+        weights.map { it * 6 }.forEach { map[it] = (map[it] ?: 0) + 1 }
+
+        var ans = 0L
+        map.forEach { (weight, count) ->
+            // 같은 몸무게인 사람들의 쌍의 개수 누적
+            ans += count * (count - 1) / 2
+
+            // 시소 짝꿍이 될 수 있는 무게를 탐색하고 쌍의 개수 누적
+            rates.forEach {
+                ans += count * (map[weight * it.second / it.first] ?: 0)
+            }
+        }
+
+        return ans
+    }
+}

--- a/#10 230208/Q3_Pro_110 옮기기/Solution.kt
+++ b/#10 230208/Q3_Pro_110 옮기기/Solution.kt
@@ -1,0 +1,54 @@
+import java.util.LinkedList
+
+class Solution {
+    val stack = LinkedList<Char>() // 변환 결과를 저장할 스택
+    val ans = LinkedList<String>()
+
+    fun solution(s: Array<String>): Array<String> {
+        s.forEach { bits ->
+            init()
+            convert(bits)
+        }
+
+        return ans.toTypedArray()
+    }
+
+    fun init() = stack.clear()
+
+    fun convert(bits: String) {
+        bits.forEach { bit ->
+            when {
+                // case 1: 스택이 비어있거나 현재 비트가 1 -> 스택에 비트 삽입
+                stack.isEmpty() || bit == '1' -> stack.add(bit)
+
+                // case 2: 비트가 0 이지만 110은 아님 -> 스택에 비트 삽입
+                bit == '0' && !isValid() -> stack.add(bit)
+
+                // case 3: 비트가 0이고 110이 된다 -> 변환 수행
+                else -> {
+                    // 앞서 비트 1 두개를 꺼냄
+                    stack.pollLast()
+                    stack.pollLast()
+
+                    // 스택에 0이 나올때 까지 꺼냄
+                    var count = 0
+                    while (stack.isNotEmpty() && stack.peekLast() == '1') {
+                        stack.pollLast()
+                        count++
+                    }
+
+                    // 110삽입 후 1비트를 꺼낸 만큼 재삽입
+                    stack.addAll(listOf('1', '1', '0'))
+                    stack.addAll(List(count) { '1' })
+                }
+            }
+        }
+
+        ans.add(stack.joinToString(""))
+    }
+
+    // 스택의 최근 두 비트가 모두 1인지 체크하는 함수
+    fun isValid() = with(stack.takeLast(2)) {
+        return@with size == 2 && all { it == '1' }
+    }
+}


### PR DESCRIPTION
### Q1. 프로그래머스_뒤에 있는 큰 수 찾기 (Success)
1. **난이도** : Level 2
2. **풀이 핵심** : 스택
3. **복잡도** : O(n) = O(10^6)

4. **전체적인 알고리즘**
      - **numbers 배열을 순회하며 원소(이하 num)를 스택에 삽입한다.**
      - 스택에 삽입할 때는 num과 num의 인덱스를 모두 삽입하여 정답 배열 갱신에 용이하도록 한다.
      - **num의 인덱스 -> num 의 순서로 삽입**한다면 stack.top()을 통해 num 값을 얻을 수 있다.
      - num을 스택에 삽입하며 다음과 같은 경우에 따라 처리한다.
            **1. 스택이 비어있음** -> 단순 삽입
            **2. 스택의 top이 num 이상** -> 단순 삽입
            **3. 스택의 top이 num 미만** -> top의 뒷 큰수가 num이 된다.

      - 이후 아직 스택에 남아있는 num은 뒷 큰수가 존재하지 않는다.

---

### Q2. 시소 짝꿍 (Success)
1. **난이도** : Level 2
2. **풀이 핵심** : HashMap
3. **복잡도** : O(n) = O(10^5)

4. **전체적인 알고리즘**
      - 시소 짝꿍이 될 수 있는 경우는 아래와 같다.
            1. 무게가 같다.
            2. 나의 무게 = 상대방의 무게 * 3/2
            3. 나의 무게 = 상대방의 무게 * 2
            4. 나의 무게 = 상대방의 무게 * 4/3
            
      - 중복을 방지하기 위해 상대방의 무게가 나보다 크다는 가정을 두었다.  
      - 특정 무게(w)인 사람 수가 x라면 w인 사람 끼리 짝을 짓는 경우는 **xC2 = x * (x - 1) / 2** 이고
      - w와 짝이 되는 무게(w')인 사람 수가 y이면 해당 사람들 끼리 짝을 짓는 경우는 **x * y**가 될 것이다.
      - 따라서 무게 별 사람의 수를 저장하기 위해 HashMap을 유지하며
      - 이때 무게에 비율을 적용할 때 소수점을 방지하기 위해 2와 3의 최소공배수 6을 곱해 저장하였다.
---

### Q3. 프로그래머스_110 옮기기 (Fail)
1. **난이도** : Level 3
2. **풀이 핵심** : 스택
3. **복잡도** : O(n) = O(10^6)

4. **전체적인 알고리즘**
      - 변환한 결과가 사전 순으로 앞에 오도록 하기 위해서는 110을 마지막 0 뒤로 옮겨야 한다.
    
      - 주어진 비트를 스택에 차례로 삽입한다.
      - 만약 삽입하려는 비트가 0이고 최근에 삽입한 두 비트가 모두 1이면 110이 등장한 것으로 판단한다.
      - 스택의 top이 0일 때까지 pop 하며 이때 꺼낸 1의 개수(count)를 누적한다.
      - 스택에 110을 삽입하고 앞서 꺼낸 1을 count 만큼 재삽입한다.

5. **왜 틀렸는가**
      - 알고리즘에 치명적인 오류는 없다고 생각하여 반례를 찾고자 하였다. 
      - 결국 반례를 찾지 못하였다.