### PR TITLE
#12, 13 Retry YoonJae

### DIFF
--- a/#12 230220/pro_억억단을 외우자/Solution.java
+++ b/#12 230220/pro_억억단을 외우자/Solution.java
@@ -3,9 +3,16 @@ public class Solution {
     static int[] solution(int e, int[] starts) {
         int[] answer = {};
         int[] divisor = new int[e + 1];
-        for(int i = 1; i <= e; i++){
-            divisor[i] = div(i);
+//        for(int i = 1; i <= e; i++){
+//            divisor[i] = div(i);
+//        }
+        // New code start
+        for (int i = 1; i <= e; i++) {
+            for (int j = 1; j <= e / i; j++) {
+                divisor[i * j]++;
+            }
         }
+        // New code end
         int max = 0;
         int[] dp = new int[e + 1];
         for(int i = e; i > 0; i--){
@@ -20,14 +27,6 @@ public class Solution {
             answer[i] = dp[starts[i]];
         }
         return answer;
-    }
-    static int div(int n){
-        int cnt = 0;
-        for(int i = 1; i * i <= n; i++){
-            if(i * i == n) cnt++;
-            else if(n % i == 0) cnt += 2;
-        }
-        return cnt;
     }
     public static void main(String[] args) throws IOException {
         int e = 8;

--- a/#13 230222/Boj 가계부(Hard)/Main.java
+++ b/#13 230222/Boj 가계부(Hard)/Main.java
@@ -1,0 +1,103 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+    static StringTokenizer st;
+    static int N, Q;
+    static SegmentTree segmentTree;
+    static class SegmentTree{
+        long tree[]; //각 원소가 담길 트리
+        int treeSize; // 트리의 크기
+
+        public SegmentTree(int arrSize){
+            // 트리 높이 구하기
+            int h = (int) Math.ceil(Math.log(arrSize)/ Math.log(2));
+            // 높이를 이용한 배열 사이즈 구하기
+            this.treeSize = (int) Math.pow(2,h+1);
+            // 배열 생성
+            tree = new long[treeSize];
+        }
+        // arr = 원소배열, node = 현재노드, start = 현재구간 배열 시작, start = 현재구간 배열 끝
+        public long init(long[] arr, int node, int start,int end){
+            // 배열의 시작과 끝이 같다면 leaf 노드이므로
+            // 원소 배열 값 그대로 담기
+            if(start == end){
+                return tree[node] = arr[start];
+            }
+
+            // leaf 노드가 아니면, 자식노드 합 담기
+            return tree[node] =
+                    init(arr,node*2,start,(start+ end)/2)
+                            + init(arr,node*2+1,(start+end)/2+1,end);
+        }
+        // node: 현재노드 idx, start: 배열의 시작, end:배열의 끝
+        // idx: 변경된 데이터의 idx, diff: 원래 데이터 값과 변경 데이터값의 차이
+        public void update(int node, int start, int end, int idx, long diff){
+            // 만약 변경할 index 값이 범위 바깥이면 확인 불필요
+            if(idx < start || end < idx) return;
+
+            // 차를 저장
+            tree[node] += diff;
+
+            // 리프노드가 아니면 아래 자식들도 확인
+            if(start != end){
+                update(node*2, start, (start+end)/2, idx, diff);
+                update(node*2+1, (start+end)/2+1, end, idx, diff);
+            }
+        }
+        // node: 현재 노드, start : 배열의 시작, end : 배열의 끝
+        // left: 원하는 누적합의 시작, right: 원하는 누적합의 끝
+        public long sum(int node, int start, int end, int left, int right){
+            // 범위를 벗어나게 되는 경우 더할 필요 없음
+            if(left > end || right < start){
+                return 0;
+            }
+
+            // 범위 내 완전히 포함 시에는 더 내려가지 않고 바로 리턴
+            if(left <= start && end <= right){
+                return tree[node];
+            }
+
+            // 그 외의 경우 좌 / 우측으로 지속 탐색 수행
+            return sum(node*2, start, (start+end)/2, left, right)+
+                    sum(node*2+1, (start+end)/2+1, end, left, right);
+        }
+    }
+    static void input() throws IOException{
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+        segmentTree = new SegmentTree(N);
+    }
+    static void solve() throws IOException{
+        for(int i = 0; i < Q; i++) {
+            st = new StringTokenizer(br.readLine());
+            int query = Integer.parseInt(st.nextToken());
+            switch (query){
+                case 1:
+                    int idx = Integer.parseInt(st.nextToken());
+                    int diff = Integer.parseInt(st.nextToken());
+                    segmentTree.update(1, 1, N, idx, diff);
+                    break;
+                case 2:
+                    int left = Integer.parseInt(st.nextToken());
+                    int right = Integer.parseInt(st.nextToken());
+                    sb.append(segmentTree.sum(1, 1, N, left, right)).append("\n");
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    public static void main(String[] argrs) throws IOException {
+        input();
+        solve();
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
### Q1. 프로그래머스 억억단을 외우자(Finally)
1. **난이도** : Level 3
2. **풀이 핵심** : dp, 소수 구하기
3. **복잡도** : O(eloge)
4. **전체적인 알고리즘** : 
- 특정 숫자가 억억단에 등장하는 횟수는 그 숫자의 약수의 개수와 같음
- 입력된 e까지 숫자의 약수의 개수를 divisor 배열에 저장
- e에서 1까지 내려가며 숫자 i의 약수의 개수가 현재 최대 개수보다 크거나 같으면 해당하는 숫자를 dp[i]에 저장
- 그렇지 않은 경우는 최대 값을 가진 숫자를 유지(dp[i] = dp[i+1])
5. **틀린 이유** : 
- 숫자 하나하나에 대해 각 숫자의 약수를 구하는 알고리즘을 구현했었는데 시간초과가 남
- 반복문으로 각 숫자를 돌며 배열의 그 숫자의 위치에 값을 더해주는 방법을 사용하니 복잡도가 확 줄어듬
-----------------------------------
### Q2. 가계부(Hard)(Finally)
1. **난이도** : Gold 1
2. **풀이 핵심** : 세그먼트 트리
3. **복잡도** : O(QlogN)
4. **세그먼트 트리란** : 
- 특정 구간 내 데이터에 대한 연산(쿼리)을 빠르게 구할 수 있는 트리
  - 변경과 연산에 대한 복잡도 : O(logN)
- 세그먼트 트리는 이진 트리 구조를 가짐
  - 좌, 우 자식 노드들은 각각 부모 노드 idx의 2배, 2배 + 1의 idx값을 가짐
  - 트리의 높이 h는 배열의 길이가 N일 때 밑이 2인 logN(올림) 값이 됨
  - 트리의 크기는 2^(h + 1) - 1 
5. **전체적인 알고리즘** : 
- 쿼리의 크기만큼 추가(update)와 출력(sum)의 동작을 반복해 줌
- Update : 루트 노드를 시작으로 idx의 부모가 되는 노드들을 이분탐색 형식으로 찾아 차이를 더 해줌
- Sum : 마찬가지로 루트 노드를 시작으로 이분 탐색을 진행하는데 구하고자 하는 범위를 완전히 포함하면 더 내려가지 않고 리턴
6. **회고** : 
- 세그먼트 트리에 대해 구현하는 방법을 몰랐기 때문에 공부를 하면서 풀어봄
- 주석이 이해하기 쉽게 달려있는 블로그를 찾아 세그먼트 트리 구현을 주석 포함 그대로 긁어서 사용해 봄(출처 : https://cano721.tistory.com/38)
- 세그먼트 트리에 대해 잘 모르는 스터디원은 한번 꼼꼼히 읽어보면 좋을듯!