### PR TITLE
#15, 16 Retry YoonJae

### DIFF
--- a/#15 230306/Boj_25498 핸들 뭘로 하지/Main.java
+++ b/#15 230306/Boj_25498 핸들 뭘로 하지/Main.java
@@ -30,6 +30,77 @@ public class Main {
         Queue<Integer> queue = new LinkedList<>();
         visited[1] = true;
         queue.offer(1);
+        sb.append(str.charAt(1));
+        while(!queue.isEmpty()){
+            char max = Character.MIN_VALUE; // 현재 사전 상 가장 후순위 값
+            List<Integer> tempList = new ArrayList<>(); // 탐색할 가치 있는 노드들
+            int size = queue.size();
+            // 현재 큐에 있는(같은 레벨에 있는) 모든 노드에 대해 한 루프 안에서 탐색
+            for(int i = 0; i < size; i++) {
+                int cur = queue.poll();
+                for (int next : tree.get(cur)) {
+                    if (visited[next]) continue;
+                    // 최대값보다 작으면 사전상 후순위가 아니므로 탐색할 필요 없음
+                    if (str.charAt(next) < max) continue;
+
+                    // 현재 큐가 비어있거나 최대값이 갱신되면 리스트 초기화
+                    if (str.charAt(next) > max) {
+                        tempList = new ArrayList<>();
+                        max = str.charAt(next);
+                    }
+                    tempList.add(next);
+                }
+            }
+            for(int i : tempList){
+                visited[i] = true;
+                queue.offer(i);
+            }
+            if(max != Character.MIN_VALUE) sb.append(max);
+        }
+    }
+    public static void main(String[] argrs) throws IOException {
+        input();
+        solve();
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}
+
+/*
+import java.io.*;
+import java.util.*;
+public class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    static StringBuilder sb = new StringBuilder();
+    static StringTokenizer st;
+    static List<List<Integer>> tree;
+    static int N, u, v;
+    static String str;
+    static boolean visited[];
+    static void input() throws IOException{
+        N = Integer.parseInt(br.readLine());
+        str = " " + br.readLine();
+        tree = new ArrayList<>();
+        visited = new boolean[N + 1];
+        for(int i = 0; i <= N; i++){
+            tree.add(new ArrayList<>());
+        }
+        for(int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            u = Integer.parseInt(st.nextToken());
+            v = Integer.parseInt(st.nextToken());
+            tree.get(u).add(v);
+            tree.get(v).add(u);
+        }
+    }
+    static void solve(){
+        // 사전상 마지막에 오는 단어를 가진 노드를 찾아 그 노드만 탐색하며 핸들을 만들어준다.
+        Queue<Integer> queue = new LinkedList<>();
+        visited[1] = true;
+        queue.offer(1);
         while(!queue.isEmpty()){
             int cur = queue.poll();
             sb.append(str.charAt(cur));
@@ -56,3 +127,4 @@ public class Main {
     }
 }
 
+*/

--- a/#16 230308/Boj_17143 낚시왕/Main.java
+++ b/#16 230308/Boj_17143 낚시왕/Main.java
@@ -58,6 +58,26 @@ public class Main {
                 if(sharks[cur_shark] == null) continue; // 죽은 상어는 continue
                 map[sharks[cur_shark].row][sharks[cur_shark].col] = 0; // 현재 상어 위치 비워줌
                 move(cur_shark); // 상어 이동
+            }
+            for(int cur_shark = 0; cur_shark < sharks.length; cur_shark++) {
+                if(sharks[cur_shark] == null) continue; // 죽은 상어는 continue
+                int other_shark = map[sharks[cur_shark].row][sharks[cur_shark].col]; // 다른 상어(없으면 0)
+                if (other_shark != 0) { // 다른 상어 존재
+                    if (sharks[other_shark].size < sharks[cur_shark].size) {
+                        sharks[other_shark] = null; // 다른 상어 잡아먹음
+                        map[sharks[cur_shark].row][sharks[cur_shark].col] = cur_shark; // 해당 위치에 현재 상어
+                    } else {
+                        sharks[cur_shark] = null; // 현재 상어 잡아먹힘
+                    }
+                } else {
+                    map[sharks[cur_shark].row][sharks[cur_shark].col] = cur_shark; // 다른 상어 없으면 해당 위치에 현재 상어
+                }
+            }
+            /*
+            for(int cur_shark = 0; cur_shark < sharks.length; cur_shark++){
+                if(sharks[cur_shark] == null) continue; // 죽은 상어는 continue
+                map[sharks[cur_shark].row][sharks[cur_shark].col] = 0; // 현재 상어 위치 비워줌
+                move(cur_shark); // 상어 이동
                 int other_shark = map[sharks[cur_shark].row][sharks[cur_shark].col]; // 다른 상어(없으면 0)
                 if(other_shark != 0){ // 다른 상어 존재
                     if(sharks[other_shark].size < sharks[cur_shark].size){
@@ -72,6 +92,7 @@ public class Main {
                     map[sharks[cur_shark].row][sharks[cur_shark].col] = cur_shark; // 다른 상어 없으면 해당 위치에 현재 상어
                 }
             }
+             */
         }
         sb.append(result);
     }


### PR DESCRIPTION
### Q1. 핸들 뭘로 하지 (Finally)
1. **난이도** : Gold 2
2. **풀이 핵심** : bfs
3. **복잡도** : O(N^2)
- 같은 레벨에 같은 문자로만 구성된 최악의 경우 모든 노드를 탐색해봐야 하는게 아닌가?
4. **전체적인 알고리즘** : 
- 1번 노드부터 bfs 탐색을 한다.
- 이 때 현재 큐에 있는(같은 레벨에 있는) 모든 노드에 대해 한 루프 안에서 탐색한다.
- 정답 문자열에 들어갈 후보 노드들을 저장할 리스트를 만든다.
- 한 루프 안에서 최대값(사전 후순위)이 갱신 될 때마다 리스트를 초기화 해주고 탐색할 가치가 있는 노드들을 리스트에 추가한다.
- 한 레벨에 대한 탐색이 끝나면 최대값을 정답 문자열에 추가하고 리스트에 있는 값을 큐에 추가하여 탐색을 계속한다.
- 큐가 비워지면 탐색을 종료한다.
5. **회고** : 
- 노드 하나 당 한 번의 루프에서 돌리는 것이 아닌 같은 레벨에 대해서 같은 알파벳을 갖는 노드를 모두 탐색해야 했다.
- 큐 사이즈 만큼 for문을 도는데 for문 안에서 큐의 사이즈가 바뀔수 있게 코딩하여 많이 헤맸다.
-----------------------------------
### Q3. 낚시왕 (Finally)
1. **난이도** : Gold 1
2. **풀이 핵심** : 구현
3. **복잡도** : O(C * (R + M))
4. **전체적인 알고리즘(두꺼운 글씨 외 이전 pr과 동일)** : 
- 존재하는 상어들을 배열로 관리해줬다.(죽으면 null)
- 배열로 관리했기 때문에 각 상어는 고유 index를 가졌고 이를 map에 표시함으로서 해당 위치에 어떤 상어가 존재하는지 명확하게 하였다.
- 낚시왕이 이동 할 때마다 2가지 작업을 수행한다.
  - 위에서부터 행을 내려오며 상어가 발견되면 잡고 break
  - 남아있는 모든 상어들을 조건에 맞게 이동시킨다.
- 상어 이동 알고리즘 :
  - 현재 상어의 위치를 비워준다(이동할 것이기 때문)
  - 조건에 맞게 상어를 이동시킨다
    - speed는 특정 주기를 갖고 반복되므로 speed를 특정 주기로 나눈 나머지를 사용했다.
    - 한 칸씩 이동하다 map을 벗어나면 방향을 바꿔주었다.
  - **상어들의 이동이 모두 완료된 후 한 마리씩 이동한 위치에 해당 상어의 고유 index를 표시해준다.**
  - 이동한 위치에 다른 상어가 만약 존재하면 상어끼리 크기를 비교하고 작은 상어는 null로 만든 후 해당 위치에 현재 상어의 index를 저장한다.
- 잡은 상어의 크기의 합을 출력한다.
5. **회고** : 
- 준영님의 리뷰로 알고리즘의 치명적인 오류를 발견 했다.
- 상어가 모두 이동한 후 겹치는지 확인 했어야 했는데 기존 코드는 이동하기 전 상어와 이동한 후 상어가 충돌하는 경우가 있었다.